### PR TITLE
Add brackets around literal 'children' in forceShow

### DIFF
--- a/src/components/VisuallyHidden/VisuallyHidden.js
+++ b/src/components/VisuallyHidden/VisuallyHidden.js
@@ -27,7 +27,7 @@ const VisuallyHidden = ({ children, ...delegated }) => {
   }, []);
 
   if (forceShow) {
-    return children;
+    return {children};
   }
 
   return <Wrapper {...delegated}>{children}</Wrapper>;


### PR DESCRIPTION
I had adapted this component for one of my projects, and was wondering why it showed the word "children" everywhere when I hit the option key 😄